### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [ '3.0', 2.7, 2.6, 2.5, head ]
+        ruby-version: [ 3.1, '3.0', 2.7, 2.6, 2.5, head ]
         os: [ ubuntu-latest, macos-latest ]
         TEST_SYMLINK: [ yes, no ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.