### PR TITLE
Don't check for c_return binding support, as we plan to remove it in Ruby 3.2

### DIFF
--- a/lib/power_assert.rb
+++ b/lib/power_assert.rb
@@ -5,12 +5,16 @@
 begin
   unless defined?(Byebug)
     captured = false
-    TracePoint.new(:return, :c_return) do |tp|
+    o = Class.new do
+      def a; 1 end
+      alias b a
+    end.new
+    TracePoint.new(:return) do |tp|
       captured = true
       unless tp.binding and tp.return_value and tp.callee_id
         raise ''
       end
-    end.enable { __id__ }
+    end.enable { o.b }
     raise '' unless captured
   end
 rescue


### PR DESCRIPTION
This calls TracePoint#inspect, which is defined in Ruby in all supported versions of Ruby.