### PR TITLE
Make the test suite compatible with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
         ruby-version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         TEST_SYMLINK: [ yes, no ]
+        include:
+          - ruby-version: "3.3"
+            os: "ubuntu-latest"
+            TEST_SYMLINK: yes
+            rubyopt: "--enable-frozen-string-literal"
     runs-on: ${{ matrix.os }}
     env:
       TEST_SYMLINK: ${{ matrix.TEST_SYMLINK }}
@@ -32,7 +37,7 @@ jobs:
           bundle exec rake before_script
       - name: Run the test suite
         run: |
-          bundle exec rake
+          bundle exec rake RUBYOPT="${{ matrix.rubyopt }}"
       - name: Run after_script
         run: |
           bundle exec rake after_script

--- a/lib/power_assert/inspector.rb
+++ b/lib/power_assert/inspector.rb
@@ -49,13 +49,13 @@ module PowerAssert
         if PowerAssert.configuration.inspector == :pp
           console_width = IO.respond_to?(:console_size) ? IO.console_size[1] : 80
           width = [console_width - 1 - @indent, 10].max
-          IRB::ColorPrinter.pp(@value, '', width)
+          IRB::ColorPrinter.pp(@value, +'', width)
         else
           IRB::Color.colorize_code(@value.to_s, ignore_error: true)
         end
       else
         if PowerAssert.configuration.inspector == :pp
-          PP.pp(@value, '')
+          PP.pp(@value, +'')
         else
           @value.inspect
         end

--- a/test/block_test.rb
+++ b/test/block_test.rb
@@ -428,9 +428,9 @@ END
   sub_test_case 'assertion_message_with_incompatible_encodings' do
     if Encoding.default_external == Encoding::UTF_8
       t do
-        a = "\u3042"
+        a = +"\u3042"
         def a.inspect
-          super.encode('utf-16le')
+          super.encode(Encoding::UTF_16LE)
         end
         assert_equal <<END.chomp, assertion_message {
           a + a
@@ -445,9 +445,9 @@ END
     end
 
     t do
-      a = "\xFF"
+      a = +"\xFF"
       def a.inspect
-        "\xFF".force_encoding('ascii-8bit')
+        "\xFF".dup.force_encoding(Encoding::BINARY)
       end
       assert_equal <<END.chomp.b, assertion_message {
         a.length


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205

Since `power_assert` is tested as part of ruby-core CI, it needs to be compatible with the `--enable-frozen-string-literal` option.