### PR TITLE
Support `opt_new`

### DIFF
--- a/lib/power_assert/context.rb
+++ b/lib/power_assert/context.rb
@@ -26,9 +26,11 @@ module PowerAssert
         if (tp.event == :c_return && diff == 1 || tp.event == :return && diff <= 2) and Thread.current == @target_thread
           idx = -(base_caller_length + 1)
           if @parser.path == locs[idx].path and @parser.lineno == locs[idx].lineno
+            ret = tp.return_value
+            ret = tp.self if method_id == :initialize
             val = PowerAssert.configuration.lazy_inspection ?
-              tp.return_value :
-              InspectedValue.new(SafeInspectable.new(tp.return_value).inspect)
+              ret :
+              InspectedValue.new(SafeInspectable.new(ret).inspect)
             @return_values << Value[method_id.to_s, val, locs[idx].lineno, nil]
           end
         end

--- a/lib/power_assert/parser.rb
+++ b/lib/power_assert/parser.rb
@@ -175,7 +175,11 @@ module PowerAssert
         end
       when :@ident, :@const, :@op
         _, method_name, (_, column) = sexp
-        [Ident[:method, method_name, column]]
+        m = [Ident[:method, method_name, column]]
+        if method_name == "new"
+          m << Ident[:method, "initialize", column]
+        end
+        m
       else
         []
       end


### PR DESCRIPTION
This commit tries to treat `new` also as `initialize` so that we don't need to disable `opt_new` when TracePoint is enabled.  This commit will make power_assert work with this PR:

  https://github.com/ruby/ruby/pull/13232