### PR TITLE
Bump version to 3.0.0.dev

### DIFF
--- a/lib/power_assert/version.rb
+++ b/lib/power_assert/version.rb
@@ -1,3 +1,3 @@
 module PowerAssert
-  VERSION = "3.0.0dev"
+  VERSION = "3.0.0.dev"
 end


### PR DESCRIPTION
Currently power_assert is not being installed in ruby master.

See https://github.com/ruby/ruby-dev-builder/actions/runs/15991588574/job/45105775185#step:19:414 and https://github.com/MSP-Greg/ruby-loco/actions/runs/15994752436/job/45115516776#step:9:2461.

The fix is to change the version string from `"3.0.0dev"` to `"3.0.0.dev"`.

I'm not sure where the issue is, as it may be code called by `make install` or code in RubyGems.  Re formatting issues, semver.org has a loose spec for pre-release version strings, they prefer a `-` delimiter between the patch identifier and the pre-release identifier.

Once this is changed, https://github.com/ruby/ruby/blob/master/gems/bundled_gems needs the version and commit updated.


cc: @nobu and @hsbt