### PR TITLE
Remove clearing the method cache

### DIFF
--- a/lib/power_assert.rb
+++ b/lib/power_assert.rb
@@ -28,7 +28,6 @@ module PowerAssert
 
   class << self
     def start(assertion_proc_or_source, assertion_method: nil, source_binding: TOPLEVEL_BINDING)
-      clear_global_method_cache
       yield Context.new(assertion_proc_or_source, assertion_method, source_binding)
     end
 
@@ -48,16 +47,5 @@ module PowerAssert
         file.start_with?(dir)
       end
     end
-
-    CLEAR_CACHE_ISEQ = RubyVM::InstructionSequence.compile('using PowerAssert.const_get(:Empty)')
-    private_constant :CLEAR_CACHE_ISEQ
-
-    def clear_global_method_cache
-      CLEAR_CACHE_ISEQ.eval
-    end
   end
-
-  module Empty
-  end
-  private_constant :Empty
 end

--- a/test/block_test.rb
+++ b/test/block_test.rb
@@ -351,19 +351,17 @@ END
       end
     end
 
-    if PowerAssert.respond_to?(:clear_global_method_cache, true)
-      t do
-        3.times do
-          assert_equal <<END.chomp, assertion_message {
-            String == Array
-            |      |  |
-            |      |  Array
-            |      false
-            String
+    t do
+      3.times do
+        assert_equal <<END.chomp, assertion_message {
+          String == Array
+          |      |  |
+          |      |  Array
+          |      false
+          String
 END
-            String == Array
-          }
-        end
+          String == Array
+        }
       end
     end
   end


### PR DESCRIPTION
It was added in https://github.com/ruby/power_assert/commit/ef6f12f8b27608c0be7cd538528995f105c02285
However, the added test passes without it in all supported ruby versions