### PR TITLE
Use the prism ripper translator if available

### DIFF
--- a/lib/power_assert/parser.rb
+++ b/lib/power_assert/parser.rb
@@ -1,8 +1,17 @@
-require 'ripper'
-
 module PowerAssert
   class Parser
     Ident = Struct.new(:type, :name, :column)
+
+    # Prism is the default parser since Ruby 3.4. It contains a compatibility layer
+    # with ripper that returns data in the same format that ripper would.
+    RipperImplementation = begin
+      gem "prism", ">= 1.0.0"
+      require "prism"
+      Prism::Translation::Ripper
+    rescue LoadError
+      require "ripper"
+      Ripper
+    end
 
     attr_reader :line, :path, :lineno, :binding
 
@@ -18,7 +27,7 @@ module PowerAssert
     end
 
     def idents
-      @idents ||= extract_idents(Ripper.sexp(@line_for_parsing))
+      @idents ||= extract_idents(RipperImplementation.sexp(@line_for_parsing))
     end
 
     def call_paths

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,6 @@ end
 
 require 'test/unit'
 require 'power_assert'
-require 'ripper'
 
 module PowerAssertTestHelper
   class << self


### PR DESCRIPTION
Since ruby 3.4, prism is the default parser. There is talk about deprecating ripper in https://bugs.ruby-lang.org/issues/21827.

In order to make possible, bundled/default gems need to not use ripper. Prism actually contains a compatibility layer which can be used for that. It translates the native prism ast into the format that ripper would return.

So, instead of rewriting the whole logic to use native prism, it can just use the compatiblity layer.

I would be open trying to port it to prism without the compatiblity layer if you prefer. That would entail keeping two implementations around, since prism is only able to parse ruby 3.3+ syntax. Let me know what you think.

A little bit more info: https://github.com/ruby/prism/blob/main/docs/ripper_translation.md