### PR TITLE
Add ability to configure parser

### DIFF
--- a/lib/power_assert/configuration.rb
+++ b/lib/power_assert/configuration.rb
@@ -1,7 +1,7 @@
 module PowerAssert
   class << self
     def configuration
-      @configuration ||= Configuration[false, true, false, :p]
+      @configuration ||= Configuration[false, true, false, :p, :ripper]
     end
 
     def configure
@@ -9,7 +9,7 @@ module PowerAssert
     end
   end
 
-  class Configuration < Struct.new(:lazy_inspection, :_redefinition, :colorize_message, :inspector)
+  class Configuration < Struct.new(:lazy_inspection, :_redefinition, :colorize_message, :inspector, :parser)
     def colorize_message=(bool)
       if bool
         require 'irb/color'
@@ -38,6 +38,18 @@ module PowerAssert
       when :p
       else
         raise ArgumentError, "unknown inspector: #{inspector}"
+      end
+      super
+    end
+
+    def parser=(parser)
+      case parser
+      when :prism
+        require 'prism'
+      when :ripper
+        require 'ripper'
+      else
+        raise ArgumentError, "unknown parser: #{parser}"
       end
       super
     end

--- a/lib/power_assert/context.rb
+++ b/lib/power_assert/context.rb
@@ -30,7 +30,8 @@ module PowerAssert
             line ||= File.open(path) {|fp| fp.each_line.drop(lineno - 1).first }
           end
           if line
-            @parser = Parser::RipperParser.new(line, path, lineno, @assertion_proc.binding, assertion_method.to_s, @assertion_proc)
+            parser_class = PowerAssert.configuration.parser == :prism ? Parser::PrismParser : Parser::RipperParser
+            @parser = parser_class.new(line, path, lineno, @assertion_proc.binding, assertion_method.to_s, @assertion_proc)
           end
         end
       end


### PR DESCRIPTION
This provides the ability to set the configured parser, switching between ripper and prism when prism is available.