### PR TITLE
Don't disable specialized instructions

### DIFF
--- a/lib/power_assert/enable_tracepoint_events.rb
+++ b/lib/power_assert/enable_tracepoint_events.rb
@@ -46,8 +46,3 @@ if PowerAssert.configuration._redefinition
     end
   end
 end
-
-# disable optimization
-RubyVM::InstructionSequence.compile_option = {
-  specialized_instruction: false
-}

--- a/test/block_test.rb
+++ b/test/block_test.rb
@@ -1,7 +1,3 @@
-if ! RubyVM::InstructionSequence.compile_option[:specialized_instruction]
-  warn "#{__FILE__}: specialized_instruction is set to false"
-end
-
 require_relative 'test_helper'
 
 class TestBlockContext < Test::Unit::TestCase

--- a/test/dyna_symbol_key_test.rb
+++ b/test/dyna_symbol_key_test.rb
@@ -1,7 +1,3 @@
-if ! RubyVM::InstructionSequence.compile_option[:specialized_instruction]
-  warn "#{__FILE__}: specialized_instruction is set to false"
-end
-
 require_relative 'test_helper'
 
 class TestDynaSymbolKey < Test::Unit::TestCase

--- a/test/safe_op_test.rb
+++ b/test/safe_op_test.rb
@@ -1,7 +1,3 @@
-if ! RubyVM::InstructionSequence.compile_option[:specialized_instruction]
-  warn "#{__FILE__}: specialized_instruction is set to false"
-end
-
 require_relative 'test_helper'
 
 class TestSafeOp < Test::Unit::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,7 +67,3 @@ module PowerAssertTestHelper
     str.gsub(/(\001)?\e\[.*?(\d)+m(\002)?/, '')
   end
 end
-
-RubyVM::InstructionSequence.compile_option = {
-  specialized_instruction: true
-}


### PR DESCRIPTION
Originally this was done in https://github.com/ruby/power_assert/commit/c23908f2b9b66b4c67fa6f27dfdc969ce3bdc63a

But it is no longer needed because ruby now emits these events regardless. Reported in https://bugs.ruby-lang.org/issues/14870 and fixed with https://github.com/ruby/ruby/commit/48c8df9e0eb295af06d593ce37ce1933c0ee1d90 (which released as part of Ruby 3.1)

In https://github.com/ruby/prism/pull/4223 we ran into this because it caused a difference in tracepoint line events

cc @eregon